### PR TITLE
Adding a new JWT exit and instructions on how to run.

### DIFF
--- a/jwt/README.md
+++ b/jwt/README.md
@@ -1,14 +1,5 @@
-This directory contains implementations of Installable Services.
-
-The only one that is used these days is the Authorisation Service. The
-IBM MQ product includes the Object Authority Manager (OAM) as its default
-implementation of this interface, but alternative implementations
-can be used to extend or replace the OAM.
+This directory contains JWT exits. For details on JWT tokens and how to use them in your applications, see the [MQ Documentation](https://ibmdocs-test.dcs.ibm.com/docs/en/SSFKSJ_9.3.0_test?topic=tokens-using-authentication-in-application)
 
 ## Contents
 
-* oamlog  - Create a logfile of all calls made to the Authorisation Service.
-* oamcrt  - Demonstrate how creation of objects can be controlled with granular
-            permissions based on the object name
-* oamok   - Report successful authentications and authorisations in a 
-            JSON-formatted log
+* extjwtexit - A sample security exit to accommodate for JWT authentication - accept a JWT token and flow it through into the MQCSP.

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -1,0 +1,14 @@
+This directory contains implementations of Installable Services.
+
+The only one that is used these days is the Authorisation Service. The
+IBM MQ product includes the Object Authority Manager (OAM) as its default
+implementation of this interface, but alternative implementations
+can be used to extend or replace the OAM.
+
+## Contents
+
+* oamlog  - Create a logfile of all calls made to the Authorisation Service.
+* oamcrt  - Demonstrate how creation of objects can be controlled with granular
+            permissions based on the object name
+* oamok   - Report successful authentications and authorisations in a 
+            JSON-formatted log

--- a/jwt/extjwtexit/.gitignore
+++ b/jwt/extjwtexit/.gitignore
@@ -1,0 +1,3 @@
+extjwtexit
+cmqc.h
+cmqxc.h

--- a/jwt/extjwtexit/README.md
+++ b/jwt/extjwtexit/README.md
@@ -1,14 +1,1 @@
-This directory contains implementations of Installable Services.
-
-The only one that is used these days is the Authorisation Service. The
-IBM MQ product includes the Object Authority Manager (OAM) as its default
-implementation of this interface, but alternative implementations
-can be used to extend or replace the OAM.
-
-## Contents
-
-* oamlog  - Create a logfile of all calls made to the Authorisation Service.
-* oamcrt  - Demonstrate how creation of objects can be controlled with granular
-            permissions based on the object name
-* oamok   - Report successful authentications and authorisations in a 
-            JSON-formatted log
+TestReadme

--- a/jwt/extjwtexit/README.md
+++ b/jwt/extjwtexit/README.md
@@ -1,1 +1,78 @@
-TestReadme
+# EXTJWTEXIT
+
+A sample security exit for authenticating with JWT Tokens issued by a third-party issuer. In this demo, the third-party issuer is KeyCloak.
+
+## OVERVIEW
+In MQ 9.3.3, a new authentication mechanism has been added into IBM MQ - authenticating via JWT Tokens issued by a third-party issuer. This sample implements a security exit to provide token authentication capability without making changes to the original messaging applications. 
+
+When called as a security exit on a Client-Connection channel, the sample will connect to an external token issuer server, retrieve a JWT Token, and adopt a pre-configured user from the Token to authenticate to the IBM MQ Queue Manager. The exit will query a token from the token endpoint using CURL, and parse the response to obtain the token to be added into the MQCSP.
+
+## BUILDING
+The code needs to be built as a 64-bit threaded, dynamically-loaded module with ChlExit as the entrypoint. When building, you must have CURL and JSON installed on your machine, and these libraries must be linked during the build. Full instructions on building channel exits can be found in the MQ documentation.
+
+Once built the exit must be copied into the MQ exits64 directory located under the MQ Data Directory (Commonly /var/mqm for UNIX).
+
+## CONFIGURATION
+
+Below are sample steps and queue manager configuration to run the JWT Token demo.
+
+On your Linux machine or environment, with MQ installed:
+1. Install curl + json sudo yum install libcurl
+   sudo yum install libcurl-devel
+   sudo yum install json-c-devel
+2. Download a copy of the security exit, and, as root, build using:
+	 gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl
+3. Create a queue manager and configure appropriately:
+   1. crtmqm DEMO
+   2. strmqm DEMO
+   3. runmqsc DEMO
+			1. ALTER QMGR CHLAUTH(DISABLED)
+			2. DEFINE LISTENER(LIST1) TRPTYPE(TCP) PORT(1513) CONTROL(QMGR)
+			3. START LISTENER(LIST1)
+			4. DEFINE CHANNEL(CHAN1) CHLTYPE(SVRCONN) SSLCAUTH(OPTIONAL)
+			5. DEFINE QLOCAL(Q1)
+4. Go into the QMGR SSL directory and configure the certificates to connect to the external AuthToken server:
+			1. cd /var/mqm/qmgrs/DEMO/ssl
+			2. runmqakm -keydb -create -db tokens.kdb -pw wibble
+			3. Retrieve the certificates and add them into the certificate keystore. There are different ways in which you can retrieve the certificates, one way would be by issuing a CURL GET command on the AuthToken server and retrieving the appropriate RSA256 certificate. Copy the certificate into a separate file, e.g. keycloak.cer (surround the certificate with -----BEGIN CERTIFICATE---- and -----END CERTIFICATE----- tags).
+			4. Add the certificate into the keystore.
+         runmqakm -cert -add -db tokens.kdb -pw wibble -file keycloak.cer -label ioWTxuAYAQui10E19s92LJP9lvGsJbhn7coWvVw6ASE
+			5. Encrypt the keystore password using the runqmcred command and save into a separate file, e.g. [keystore.pw](https://keystore.pw)
+			6. Give the keystore necessary permissions:
+         chmod g+r /var/mqm/qmgrs/DEMO/ssl/tokens.kdb
+ 5. Configure the queue manager qm.ini config file to specify the token issuer information for token validation.
+      1. cd /var/mqm/qmgrs/DEMO/
+      2. vi qm.ini
+      3. Add the new AuthToken stanza with the required information. For example:
+				 AuthToken:
+	         KeyStore=/var/mqm/qmgrs/DEMO/ssl/tokens.kdb
+				   KeyStorePwdFile=/var/mqm/qmgrs/DEMO/ssl/keystore.pw
+					 CertLabel=ioWTxuAYAQui10E19s92LJP9lvGsJbhn7coWvVw6ASE
+				   UserClaim=preferred_username
+6. Issue a REFRESH SECURITY or restart the queue manager via endmqm/strmqm. 
+7. Set the correct authority records on the queue manager. The Principal should be set to that of the incoming user from the JWT Token. The SCYDATA attribute when defining the CLNTCONN channel can be used to specify, how chatty the output should be - if set to DEBUG, the output will be more chatty.
+	 1. SET AUTHREC OBJTYPE(QMGR) PRINCIPAL('admin') AUTHADD(CONNECT)
+	 2. SET AUTHREC PROFILE(Q1) OBJTYPE(QUEUE) PRINCIPAL('admin') AUTHADD(ALLMQI)
+	 3. DEFINE CHANNEL(CHAN1) CHLTYPE(CLNTCONN) CONNAME('127.0.0.1(1513)') QMNAME(DEMO) SCYEXIT('extjwtexit(ChlExit)') SCYDATA(DEBUG)
+8. Set the appropriate environment variables for the exit:  
+	 export MQCHLLIB=/var/mqm/qmgrs/DEMO/@ipcc
+   export MQCHLTAB=AMQCLCHL.TAB
+   export JWT_TOKEN_ENDPOINT=<https://tokenendpoint.com>:/realms/master/protocol/openid-connect/token
+   export JWT_TOKEN_USERNAME=admin
+   export JWT_TOKEN_PWD=tokenuserpassword
+   export JWT_TOKEN_CLIENTID=admin-cliendid
+9. Run the amqsputc sample to confirm that the exit is running and working:
+   /opt/mqm/samp/bin/amqsputc Q1 DEMO
+
+## EXAMPLE OUTPUT
+
+[vas@dupe1 DEMO]$ /opt/mqm/samp/bin/amqsputc Q1 DEMO
+Sample AMQSPUT0 start
+> Obtaining token from endpoint 'https:[tokenserver.com](https://tokenserver.com):/realms/master/protocol/openid-connect/token' with User 'admin'
+> Global curl init
+> curl init
+> connecting!
+Got back a token response!
+Token to be used:
+eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJpb1dUeHVBWUFRdWkxMEUxOXM5MkxKUDlsdkdzSmJobjdjb1d2Vnc2QVNFIn0.eyJleHAiOjE2ODYxMzQwOTIsImlhdCI6MTY4NjEzNDAzMiwianRpIjoiNTgwODdiYTgtMDM3NC00NmM5LTgyYTYtOGRlOTBjNzEyZDFmIiwiaXNzIjoiaHR0cHM6Ly9rZXljbG9hay0yMC0wLTMubXFvcHMtc2VydmljZXMuaHVyc2xleS5pYm0uY29tL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiJjYjY0MjllMi1iYjhkLTQ5MTYtOGU1NS1mNGU5NzA3YzhhNTIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJhZG1pbi1jbGkiLCJzZXNzaW9uX3N0YXRlIjoiNzMyNjg1OTUtNDQ2ZC00YTY4LTg1ZTctYWFkMDE1Nzg1ODkzIiwiYWNyIjoiMSIsInNjb3BlIjoiZW1haWwgcHJvZmlsZSIsInNpZCI6IjczMjY4NTk1LTQ0NmQtNGE2OC04NWU3LWFhZDAxNTc4NTg5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.N3jf_kLoIK9eAVr0op6fjPF08CdsVe4GsGz9SVTBfyKLT5H9JQiPOt53-n2pBu8zpMpGxvBRCLidSrBMvpIW0NIpruD4rxN-Nu0zriTybXA1vz6GX5z4xNroIg_DPUG9nq4FUXIzxn7BBCWH_5H9nF8P_upET7SyrBfHCx2XD2Ot3NFidLVj6lx3N_bZllLa9MKfwvv9N0R_7vPM2Uw9YkWFtHjpZRpu-hp2iBEVOcgPIK6F7Uslr6JyJpKfYcdzmO14qNmxhAizCQdABy-T3RdvN15cW7hVe22bda2kFA0OotO13VICW_dNlfbqD95QINGsaI0qu3MK7P_ZQ4Qybw
+target queue is Q1

--- a/jwt/extjwtexit/README.md
+++ b/jwt/extjwtexit/README.md
@@ -2,17 +2,17 @@
 
 A sample security exit for authenticating with JWT Tokens issued by a third-party issuer. In this demo, the third-party issuer is KeyCloak.
 
-## OVERVIEW
+## Overview
 In MQ 9.3.3, a new authentication mechanism has been added into IBM MQ - authenticating via JWT Tokens issued by a third-party issuer. This sample implements a security exit to provide token authentication capability without making changes to the original messaging applications. 
 
 When called as a security exit on a Client-Connection channel, the sample will connect to an external token issuer server, retrieve a JWT Token, and adopt a pre-configured user from the Token to authenticate to the IBM MQ Queue Manager. The exit will query a token from the token endpoint using CURL, and parse the response to obtain the token to be added into the MQCSP.
 
-## BUILDING
+## Building
 The code needs to be built as a 64-bit threaded, dynamically-loaded module with ChlExit as the entrypoint. When building, you must have CURL and JSON installed on your machine, and these libraries must be linked during the build. Full instructions on building channel exits can be found in the MQ documentation.
 
 Once built the exit must be copied into the MQ exits64 directory located under the MQ Data Directory (Commonly /var/mqm for UNIX).
 
-## CONFIGURATION
+## Configuration
 
 Below are sample steps and queue manager configuration to run the JWT Token demo.
 
@@ -64,7 +64,7 @@ On your Linux machine or environment, with MQ installed:
 9. Run the amqsputc sample to confirm that the exit is running and working:
    /opt/mqm/samp/bin/amqsputc Q1 DEMO
 
-## EXAMPLE OUTPUT
+## Example Output
 
 [vas@dupe1 DEMO]$ /opt/mqm/samp/bin/amqsputc Q1 DEMO
 Sample AMQSPUT0 start

--- a/jwt/extjwtexit/README.md
+++ b/jwt/extjwtexit/README.md
@@ -1,0 +1,14 @@
+This directory contains implementations of Installable Services.
+
+The only one that is used these days is the Authorisation Service. The
+IBM MQ product includes the Object Authority Manager (OAM) as its default
+implementation of this interface, but alternative implementations
+can be used to extend or replace the OAM.
+
+## Contents
+
+* oamlog  - Create a logfile of all calls made to the Authorisation Service.
+* oamcrt  - Demonstrate how creation of objects can be controlled with granular
+            permissions based on the object name
+* oamok   - Report successful authentications and authorisations in a 
+            JSON-formatted log

--- a/jwt/extjwtexit/README.md
+++ b/jwt/extjwtexit/README.md
@@ -3,76 +3,99 @@
 A sample security exit for authenticating with JWT Tokens issued by a third-party issuer. In this demo, the third-party issuer is KeyCloak.
 
 ## Overview
-In MQ 9.3.3, a new authentication mechanism has been added into IBM MQ - authenticating via JWT Tokens issued by a third-party issuer. This sample implements a security exit to provide token authentication capability without making changes to the original messaging applications. 
+In MQ 9.3.4, a new authentication mechanism has been added into IBM MQ - authenticating via JWT Tokens issued by a third-party issuer. This sample implements a security exit to provide token authentication capability without making changes to the original messaging applications. 
 
 When called as a security exit on a Client-Connection channel, the sample will connect to an external token issuer server, retrieve a JWT Token, and adopt a pre-configured user from the Token to authenticate to the IBM MQ Queue Manager. The exit will query a token from the token endpoint using CURL, and parse the response to obtain the token to be added into the MQCSP.
 
 ## Building
 The code needs to be built as a 64-bit threaded, dynamically-loaded module with ChlExit as the entrypoint. When building, you must have CURL and JSON installed on your machine, and these libraries must be linked during the build. Full instructions on building channel exits can be found in the MQ documentation.
 
-Once built the exit must be copied into the MQ exits64 directory located under the MQ Data Directory (Commonly /var/mqm for UNIX).
+Once built the exit must be copied into the MQ exits64 directory located under the MQ Data Directory (commonly /var/mqm for UNIX).
 
 ## Configuration
 
 Below are sample steps and queue manager configuration to run the JWT Token demo.
 
 On your Linux machine or environment, with MQ installed:
-1. Install curl + json sudo yum install libcurl
-   sudo yum install libcurl-devel
-   sudo yum install json-c-devel
+1. Install curl + json
+```
+sudo yum install libcurl
+sudo yum install libcurl-devel
+sudo yum install json-c-devel
+```
 2. Download a copy of the security exit, and, as root, build using:
-	 gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl
+```
+gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl
+```
 3. Create a queue manager and configure appropriately:
    1. crtmqm DEMO
    2. strmqm DEMO
    3. runmqsc DEMO
-			1. ALTER QMGR CHLAUTH(DISABLED)
-			2. DEFINE LISTENER(LIST1) TRPTYPE(TCP) PORT(1513) CONTROL(QMGR)
-			3. START LISTENER(LIST1)
-			4. DEFINE CHANNEL(CHAN1) CHLTYPE(SVRCONN) SSLCAUTH(OPTIONAL)
-			5. DEFINE QLOCAL(Q1)
+   ```
+	ALTER QMGR CHLAUTH(DISABLED)
+	DEFINE LISTENER(LIST1) TRPTYPE(TCP) PORT(1513) CONTROL(QMGR)
+	START LISTENER(LIST1)
+	DEFINE CHANNEL(CHAN1) CHLTYPE(SVRCONN) SSLCAUTH(OPTIONAL)
+	DEFINE QLOCAL(Q1)
+    ```
 4. Go into the QMGR SSL directory and configure the certificates to connect to the external AuthToken server:
-			1. cd /var/mqm/qmgrs/DEMO/ssl
-			2. runmqakm -keydb -create -db tokens.kdb -pw wibble
-			3. Retrieve the certificates and add them into the certificate keystore. There are different ways in which you can retrieve the certificates, one way would be by issuing a CURL GET command on the AuthToken server and retrieving the appropriate RSA256 certificate. Copy the certificate into a separate file, e.g. keycloak.cer (surround the certificate with -----BEGIN CERTIFICATE---- and -----END CERTIFICATE----- tags).
-			4. Add the certificate into the keystore.
-         runmqakm -cert -add -db tokens.kdb -pw wibble -file keycloak.cer -label ioWTxuAYAQui10E19s92LJP9lvGsJbhn7coWvVw6ASE
-			5. Encrypt the keystore password using the runqmcred command and save into a separate file, e.g. [keystore.pw](https://keystore.pw)
-			6. Give the keystore necessary permissions:
-         chmod g+r /var/mqm/qmgrs/DEMO/ssl/tokens.kdb
- 5. Configure the queue manager qm.ini config file to specify the token issuer information for token validation.
-      1. cd /var/mqm/qmgrs/DEMO/
-      2. vi qm.ini
-      3. Add the new AuthToken stanza with the required information. For example:
-				 AuthToken:
-	         KeyStore=/var/mqm/qmgrs/DEMO/ssl/tokens.kdb
-				   KeyStorePwdFile=/var/mqm/qmgrs/DEMO/ssl/keystore.pw
-					 CertLabel=ioWTxuAYAQui10E19s92LJP9lvGsJbhn7coWvVw6ASE
-				   UserClaim=preferred_username
-6. Issue a REFRESH SECURITY or restart the queue manager via endmqm/strmqm. 
-7. Set the correct authority records on the queue manager. The Principal should be set to that of the incoming user from the JWT Token. The SCYDATA attribute when defining the CLNTCONN channel can be used to specify, how chatty the output should be - if set to DEBUG, the output will be more chatty.
-	 1. SET AUTHREC OBJTYPE(QMGR) PRINCIPAL('admin') AUTHADD(CONNECT)
-	 2. SET AUTHREC PROFILE(Q1) OBJTYPE(QUEUE) PRINCIPAL('admin') AUTHADD(ALLMQI)
-	 3. DEFINE CHANNEL(CHAN1) CHLTYPE(CLNTCONN) CONNAME('127.0.0.1(1513)') QMNAME(DEMO) SCYEXIT('extjwtexit(ChlExit)') SCYDATA(DEBUG)
-8. Set the appropriate environment variables for the exit:  
-	 export MQCHLLIB=/var/mqm/qmgrs/DEMO/@ipcc
-   export MQCHLTAB=AMQCLCHL.TAB
-   export JWT_TOKEN_ENDPOINT=<https://tokenendpoint.com>:/realms/master/protocol/openid-connect/token
-   export JWT_TOKEN_USERNAME=admin
-   export JWT_TOKEN_PWD=tokenuserpassword
-   export JWT_TOKEN_CLIENTID=admin-cliendid
-9. Run the amqsputc sample to confirm that the exit is running and working:
-   /opt/mqm/samp/bin/amqsputc Q1 DEMO
-
+```
+cd /var/mqm/qmgrs/DEMO/ssl
+runmqakm -keydb -create -db tokens.kdb -pw wibble
+```
+5. Retrieve the certificates and add them into the certificate keystore. There are different ways in which you can retrieve the certificates, one way would be by issuing a CURL GET command on the AuthToken server and retrieving the appropriate RSA256 certificate. Copy the certificate into a separate file, e.g. keycloak.cer (surround the certificate with -----BEGIN CERTIFICATE---- and -----END CERTIFICATE----- tags).
+6. Add the certificate into the keystore.
+```
+runmqakm -cert -add -db tokens.kdb -pw wibble -file keycloak.cer -label label1
+```
+7. Encrypt the keystore password using the runqmcred command and save into a separate file, e.g. keystore.pw
+8. Give the keystore necessary permissions:
+```         
+chmod g+r /var/mqm/qmgrs/DEMO/ssl/tokens.kdb
+```
+9. Configure the queue manager qm.ini config file to specify the token issuer information for token validation.
+```
+cd /var/mqm/qmgrs/DEMO/
+vi qm.ini
+``` 
+10. Add the new AuthToken stanza with the required information. For example:
+```
+AuthToken:
+	KeyStore=/var/mqm/qmgrs/DEMO/ssl/tokens.kdb
+	KeyStorePwdFile=/var/mqm/qmgrs/DEMO/ssl/keystore.pw
+	CertLabel=label1
+	UserClaim=preferred_username
+```
+11. Issue a REFRESH SECURITY or restart the queue manager via endmqm/strmqm. 
+12. Set the correct authority records on the queue manager. The Principal should be set to that of the incoming user from the JWT Token. The SCYDATA attribute when defining the CLNTCONN channel can be used to specify, how chatty the output should be - if set to DEBUG, the output will be more chatty.
+```
+SET AUTHREC OBJTYPE(QMGR) PRINCIPAL('admin') AUTHADD(CONNECT)
+SET AUTHREC PROFILE(Q1) OBJTYPE(QUEUE) PRINCIPAL('admin') AUTHADD(ALLMQI)
+DEFINE CHANNEL(CHAN1) CHLTYPE(CLNTCONN) CONNAME('127.0.0.1(1513)') QMNAME(DEMO) SCYEXIT('extjwtexit(ChlExit)') SCYDATA(DEBUG)
+```
+13. Set the appropriate environment variables for the exit: 
+``` 
+export MQCHLLIB=/var/mqm/qmgrs/DEMO/@ipcc
+export MQCHLTAB=AMQCLCHL.TAB
+export JWT_TOKEN_ENDPOINT=.../realms/master/protocol/openid-connect/token
+export JWT_TOKEN_USERNAME=admin
+export JWT_TOKEN_PWD=tokenuserpassword
+export JWT_TOKEN_CLIENTID=admin-cliendid
+```
+14. Run the amqsputc sample to confirm that the exit is running and working:
+```
+/opt/mqm/samp/bin/amqsputc Q1 DEMO
+```
 ## Example Output
-
+```
 [vas@dupe1 DEMO]$ /opt/mqm/samp/bin/amqsputc Q1 DEMO
 Sample AMQSPUT0 start
-> Obtaining token from endpoint 'https:[tokenserver.com](https://tokenserver.com):/realms/master/protocol/openid-connect/token' with User 'admin'
+> Obtaining token from endpoint 'https:tokenserver.com:/realms/master/protocol/openid-connect/token' with User 'admin'
 > Global curl init
 > curl init
 > connecting!
 Got back a token response!
 Token to be used:
-eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJpb1dUeHVBWUFRdWkxMEUxOXM5MkxKUDlsdkdzSmJobjdjb1d2Vnc2QVNFIn0.eyJleHAiOjE2ODYxMzQwOTIsImlhdCI6MTY4NjEzNDAzMiwianRpIjoiNTgwODdiYTgtMDM3NC00NmM5LTgyYTYtOGRlOTBjNzEyZDFmIiwiaXNzIjoiaHR0cHM6Ly9rZXljbG9hay0yMC0wLTMubXFvcHMtc2VydmljZXMuaHVyc2xleS5pYm0uY29tL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiJjYjY0MjllMi1iYjhkLTQ5MTYtOGU1NS1mNGU5NzA3YzhhNTIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJhZG1pbi1jbGkiLCJzZXNzaW9uX3N0YXRlIjoiNzMyNjg1OTUtNDQ2ZC00YTY4LTg1ZTctYWFkMDE1Nzg1ODkzIiwiYWNyIjoiMSIsInNjb3BlIjoiZW1haWwgcHJvZmlsZSIsInNpZCI6IjczMjY4NTk1LTQ0NmQtNGE2OC04NWU3LWFhZDAxNTc4NTg5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.N3jf_kLoIK9eAVr0op6fjPF08CdsVe4GsGz9SVTBfyKLT5H9JQiPOt53-n2pBu8zpMpGxvBRCLidSrBMvpIW0NIpruD4rxN-Nu0zriTybXA1vz6GX5z4xNroIg_DPUG9nq4FUXIzxn7BBCWH_5H9nF8P_upET7SyrBfHCx2XD2Ot3NFidLVj6lx3N_bZllLa9MKfwvv9N0R_7vPM2Uw9YkWFtHjpZRpu-hp2iBEVOcgPIK6F7Uslr6JyJpKfYcdzmO14qNmxhAizCQdABy-T3RdvN15cW7hVe22bda2kFA0OotO13VICW_dNlfbqD95QINGsaI0qu3MK7P_ZQ4Qybw
+eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJpb1dUeHVBWUFRdWkxMEUxOXM5MkxKUDlsdkdzSmJobjdjb1d2Vnc2QVNFIn0...Q4Qybw
 target queue is Q1
+```

--- a/jwt/extjwtexit/build_unix.sh
+++ b/jwt/extjwtexit/build_unix.sh
@@ -5,4 +5,4 @@
 
 set -e
 
-gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl
+sudo gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl

--- a/jwt/extjwtexit/build_unix.sh
+++ b/jwt/extjwtexit/build_unix.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Example build bash script for building extjwtexit using gcc.
+# (C) IBM Corporation 2023
+#
+
+set -e
+
+gcc -m64 -shared -fPIC -o /var/mqm/exits64/extjwtexit ./extjwtexit.c -I/opt/mqm/inc -ljson-c -lcurl

--- a/jwt/extjwtexit/extjwtexit.c
+++ b/jwt/extjwtexit/extjwtexit.c
@@ -1,0 +1,364 @@
+/*****************************************************************************/
+/*                                                                           */
+/* Module Name: extjwtexit.c                                                 */
+/*                                                                           */
+/* (C) IBM Corporation 2023                                                  */
+/*                                                                           */
+/* AUTHOR: Vasily Shcherbinin, IBM Hursley                                   */
+/*                                                                           */
+/*     Licensed under the Apache License, Version 2.0 (the "License");       */
+/*     you may not use this file except in compliance with the License.      */
+/*     You may obtain a copy of the License at                               */
+/*                                                                           */
+/*              http://www.apache.org/licenses/LICENSE-2.0                   */
+/*                                                                           */
+/*     Unless required by applicable law or agreed to in writing, software   */
+/*     distributed under the License is distributed on an "AS IS" BASIS,     */
+/*     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,                         */
+/*     either express or implied.                                            */
+/*                                                                           */
+/*     See the License for the specific language governing permissions and   */
+/*     limitations under the License.                                        */
+/*                                                                           */
+/* Description: Security exit that takes a Token endpoint, username          */
+/*              and password as environment variables to dynamically         */
+/*              retrieve a JWT token from a AuthToken issuer and adds it to  */
+/*              the MQCSP structure for authentication.                      */
+/*                                                                           */
+/*****************************************************************************/
+/* CURL COPYRIGHT                                                            */
+/* COPYRIGHT AND PERMISSION NOTICE                                           */
+/*                                                                           */
+/* Copyright (c) 1996 - 2023, Daniel Stenberg, <daniel@haxx.se>, and many    */
+/* contributors.                                                             */
+/*                                                                           */
+/* All rights reserved.                                                      */
+/*                                                                           */
+/* Permission to use, copy, modify, and distribute this software for any     */
+/* purpose with or without fee is hereby granted, provided that the above    */
+/* copyright notice and this permission notice appear in all copies.         */
+/*                                                                           */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR*/
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY       */
+/* RIGHTS. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR  */
+/* ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE*/ 
+/* OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                             */
+/*                                                                           */
+/* Except as contained in this notice, the name of a copyright holder shall  */
+/* not be used in advertising or otherwise to promote the sale, use or other */
+/* dealings in this Software without prior written authorization of the      */
+/* copyright holder.                                                         */
+/*****************************************************************************/
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <curl/curl.h>
+#include <json-c/json.h>
+
+#include <cmqc.h>             /* MQI header                          */
+#include <cmqxc.h>            /* Installable services header         */
+
+#if MQAT_DEFAULT == MQAT_UNIX
+#include <strings.h>
+#ifndef stricmp
+#define stricmp strcasecmp
+#endif
+#else
+#error Unsupported platform
+#endif
+
+#define   SUCCESS              0
+#define   FAILURE              1
+#define   DEBUG_OPTION         "DEBUG"
+#define   CURL_LINKAGE
+#define   NULL_POINTER (void *)0
+
+static int debugPrint = 0;
+
+/* Function prototypes */
+static int AuthTokenLogin(char *TokenEndpoint, char *UserId, char *Password, char *ClientId, char **response);
+static int obtainToken(char *TokenEndpoint, char *UserId, char *Password, char* ClientId, char **token);
+static int RetrieveTokenFromResponse(char *response, char **token);
+static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp);
+
+/* DISCLAIMER: Code sourced from https://curl.se/libcurl/c/getinmemory.html */
+struct MemoryStruct
+{
+    char *memory;
+    size_t size;
+};
+
+/* DISCLAIMER: Code sourced from https://curl.se/libcurl/c/getinmemory.html */
+static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    size_t realsize = size * nmemb;
+    struct MemoryStruct *mem = (struct MemoryStruct *)userp;
+
+    char *ptr = realloc(mem->memory, mem->size + realsize + 1);
+    if (!ptr)
+    {
+        /* out of memory! */
+        fprintf(stderr, "not enough memory (realloc returned NULL)\n");
+        return 0;
+    }
+
+    mem->memory = ptr;
+    memcpy(&(mem->memory[mem->size]), contents, realsize);
+    mem->size += realsize;
+    mem->memory[mem->size] = 0;
+
+    return realsize;
+}
+
+/*****************************************************************/
+/* Function to query a token from the token endpoint. Build the  */
+/* curl command in AuthTokenLogin and use that to retrieve       */
+/* a JSON response from the AuthToken server. Parse the          */
+/* response via RetrieveTokenFromResponse to retrieve the token  */
+/* to be added into the MQCSP.                                   */
+/*****************************************************************/
+static int obtainToken(char *TokenEndpoint, char *UserId, char *Password, char* ClientId, char **token)
+{
+    char *tokenResponse = NULL_POINTER;
+    int rc = 0;
+
+    printf("> Obtaining token from endpoint '%s' with User '%s'\n", TokenEndpoint, UserId);
+    rc = AuthTokenLogin(TokenEndpoint, UserId, Password, ClientId, &tokenResponse);
+    if (rc == 0)
+    {
+        printf("Got back a token response!\n");
+        rc = RetrieveTokenFromResponse(tokenResponse, token);
+        memset(tokenResponse, 0, strlen(tokenResponse));
+        free(tokenResponse);
+    }
+    return rc;
+}
+
+/*****************************************************************/
+/* Parse the response from the AuthToken server containing the   */
+/* JWT token in the "access_token" field. This token is later    */
+/* passed into the MQCSP structure.                              */
+/*****************************************************************/
+static int RetrieveTokenFromResponse(char *response, char **token)
+{
+    json_object *rootObj = NULL;
+    json_object *tokenStrObj = NULL;
+    char *tokenstr;
+    int tokLen = 0;
+    json_tokener *tok;
+    enum json_tokener_error jerr;
+        char *val_type_str, *str, *kid, *cert;
+    int val_type, i, i2;
+
+    if (response == NULL_POINTER)
+    {
+        return -1;
+    }
+
+    tok = json_tokener_new();
+    rootObj = json_tokener_parse_ex(tok, response, strlen(response) + 1);
+    jerr = json_tokener_get_error(tok);
+    if (jerr != json_tokener_success)
+    {
+        fprintf(stderr, "Error: %s\n", json_tokener_error_desc(jerr));
+        return -1;
+    }
+
+    json_object_object_get_ex(rootObj, "access_token", &tokenStrObj);
+    if (json_object_get_type(tokenStrObj) != json_type_string)
+    {
+        return -2;
+    }
+    tokenstr = (char *)json_object_get_string(tokenStrObj);
+    tokLen = (int) strlen(tokenstr);
+    *token = malloc(tokLen + 1);
+    memset(*token, 0, tokLen + 1);
+    memcpy(*token, tokenstr, tokLen);
+    return 0;
+}
+
+/*****************************************************************/
+/* Build the curl command to access the Token from the AuthToken */
+/* server.                                                       */
+/* DISCLAIMER: CURL interaction code source from                 */
+/*             https://curl.se/libcurl/c/getinmemory.html        */
+/*****************************************************************/
+static int AuthTokenLogin(char *TokenEndpoint, char *UserId, char *Password, char *ClientId, char **response)
+{
+    int rc = 0;
+    CURL *curl;
+    CURLcode res;
+    char POSTOPTBUILDUP[65536] = {0};
+    struct MemoryStruct chunk;
+
+    chunk.memory = malloc(1);
+    chunk.size = 0;
+
+    if (debugPrint)
+    {
+      printf("> Global curl init\n");
+    }
+    curl_global_init(CURL_GLOBAL_ALL);
+    /* Obtain token */
+    if (debugPrint)
+    {
+      printf("> curl init\n");
+    }
+    curl = curl_easy_init();
+    if (curl)
+    {
+        curl_easy_setopt(curl, CURLOPT_URL, TokenEndpoint);
+        sprintf(POSTOPTBUILDUP, "username=%s&password=%s&grant_type=password&client_id=%s", UserId, Password, ClientId);
+        /* WARNING: We are disabling Peer certificate and Host verification here for simplicity. */
+        /*          Do not do this in production!                                                */
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, POSTOPTBUILDUP);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
+        if (debugPrint)
+        {
+          printf("> connecting!\n");
+        }
+        
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK)
+        {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                    curl_easy_strerror(res));
+            rc = res;
+        }
+        else
+        {
+            *response = malloc(chunk.size + 1);
+            memset(*response, 0, chunk.size + 1);
+            memcpy(*response, chunk.memory, chunk.size);
+        }
+    }
+    else
+    {
+        /* Failed to */
+        printf("FAILED TO INIT CURL!\n");
+        rc = -2;
+    }
+
+    memset(chunk.memory, 0, chunk.size);
+    free(chunk.memory);
+
+    curl_easy_cleanup(curl);
+    /* code */
+    return rc;
+}
+
+/*********************************************************************/
+/*                                                                   */
+/* Function Name:  ChlExit                                           */
+/*                                                                   */
+/* Description: Main channel exit function. Use defined environment  */
+/*              variables to obtain a token from a AuthToken server  */
+/*              and use it for authenticating with the Queue Manager */
+/*                                                                   */
+/*********************************************************************/
+void MQENTRY ChlExit(
+  PMQVOID  pChannelExitParms,   /* Channel exit parameter block */
+  PMQVOID  pChannelDefinition,  /* Channel definition           */
+  PMQLONG  pDataLength,         /* Length of data               */
+  PMQLONG  pAgentBufferLength,  /* Length of agent buffer       */
+  PMQVOID  pAgentBuffer,        /* Agent buffer                 */
+  PMQLONG  pExitBufferLength,   /* Length of exit buffer        */
+  PMQPTR   pExitBufferAddr)     /* Address of exit buffer       */
+{
+  PMQCXP pParms = (PMQCXP)pChannelExitParms;
+  PMQCD  pCD    = (PMQCD)pChannelDefinition;
+  char scyData[MQ_EXIT_DATA_LENGTH+1] = {0};
+
+  /* Define the JWT Environment variables to retrieve Token */
+  /* from the AuthToken issuer.                              */
+  char* jwtTokenEndpoint = getenv("JWT_TOKEN_ENDPOINT");
+  char* jwtTokenUsername = getenv("JWT_TOKEN_USERNAME");
+  char* jwtTokenPassword = getenv("JWT_TOKEN_PWD");
+  char* jwtTokenClientId = getenv("JWT_TOKEN_CLIENTID");
+  char* token = NULL_POINTER;
+
+  if (pParms->ExitId == MQXT_CHANNEL_SEC_EXIT)
+  {
+    /*****************************************************************/
+    /* The MQXR_SEC_PARMS invocation for security exit is done to    */
+    /* permit the CSP structure to be filled in and passed to the    */
+    /* server. If there is already a CSP structure, then this exit   */
+    /* will not override it.                                         */
+    /*****************************************************************/
+    if (pParms->ExitReason == MQXR_SEC_PARMS)
+    {
+      strncpy(scyData,pParms->ExitData,MQ_EXIT_DATA_LENGTH);
+      scyData[MQ_EXIT_DATA_LENGTH] = 0;
+      if (strstr(scyData,DEBUG_OPTION))
+        debugPrint = TRUE;
+      if (obtainToken(jwtTokenEndpoint, jwtTokenUsername, jwtTokenPassword, jwtTokenClientId, &token) != 0)
+      {
+        pParms->ExitResponse = MQXCC_CLOSE_CHANNEL;
+      }
+      else
+      {
+        MQCSP csp = {MQCSP_DEFAULT};
+        if (debugPrint)
+        {
+          printf("Token to be used:\n%s\n", token);
+        }
+        pParms->SecurityParms = malloc(sizeof(MQCSP) + strlen(token));
+        if (pParms->SecurityParms != NULL)
+        {
+          memcpy(pParms->SecurityParms,&csp,sizeof(MQCSP));
+          pParms->SecurityParms->Version = 3;
+          pParms->SecurityParms->AuthenticationType =  MQCSP_AUTH_ID_TOKEN;
+
+          pParms->SecurityParms->TokenLength = (MQLONG)strlen(token);
+          pParms->SecurityParms->TokenOffset = sizeof(MQCSP);
+          memcpy((char *)pParms->SecurityParms + sizeof(MQCSP),token,strlen(token));
+
+          pParms->ExitUserArea[0] = SUCCESS;
+        }
+      }
+    }
+    else if (pParms->ExitReason == MQXR_TERM)
+    {
+      if (pParms->Version > 5)
+      {
+        if (pParms->SecurityParms != NULL &&
+            pParms->ExitUserArea[0] == SUCCESS)
+          free(pParms->SecurityParms);
+      }
+    }
+  }
+  return;
+}
+
+/*********************************************************************/
+/*                                                                   */
+/* Function Name:  MQStart                                           */
+/*                                                                   */
+/* Description: Entrypoint to the exit                               */
+/*********************************************************************/
+void MQENTRY MQStart ( PMQCXP  pChannelExitParms
+                     , PMQCD   pChannelDefinition
+                     , PMQLONG pDataLength
+                     , PMQLONG pAgentBufferLength
+                     , PMQVOID pAgentBuffer
+                     , PMQLONG pExitBufferLength
+                     , PMQPTR  pExitBufferAddr
+                     )
+{
+  ChlExit ( pChannelExitParms
+          , pChannelDefinition
+          , pDataLength
+          , pAgentBufferLength
+          , pAgentBuffer
+          , pExitBufferLength
+          , pExitBufferAddr
+          );
+}


### PR DESCRIPTION
Adding a folder containing a new native JWT exit to add a Token into the MQCSP, and instructions on how to run a demo using the exit. 